### PR TITLE
Implement AddOrder command

### DIFF
--- a/src/main/java/seedu/sellsavvy/logic/Messages.java
+++ b/src/main/java/seedu/sellsavvy/logic/Messages.java
@@ -54,8 +54,8 @@ public class Messages {
      */
     public static String format(Order order) {
         final StringBuilder builder = new StringBuilder();
-        builder.append(order.getItem())
-                .append("; Delivery by: ")
+        builder.append(order.getItem() + "\n")
+                .append("Delivery by: ")
                 .append(order.getDate())
                 .append("; Quantity: ")
                 .append(order.getCount());

--- a/src/main/java/seedu/sellsavvy/logic/Messages.java
+++ b/src/main/java/seedu/sellsavvy/logic/Messages.java
@@ -5,6 +5,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import seedu.sellsavvy.logic.parser.Prefix;
+import seedu.sellsavvy.model.order.Order;
 import seedu.sellsavvy.model.person.Person;
 
 /**
@@ -48,4 +49,16 @@ public class Messages {
         return builder.toString();
     }
 
+    /**
+     * Formats the {@code order} for display to the user.
+     */
+    public static String format(Order order) {
+        final StringBuilder builder = new StringBuilder();
+        builder.append(order.getItem())
+                .append("; Delivery by: ")
+                .append(order.getDate())
+                .append("; Quantity: ")
+                .append(order.getCount());
+        return builder.toString();
+    }
 }

--- a/src/main/java/seedu/sellsavvy/logic/commands/ordercommands/AddOrderCommand.java
+++ b/src/main/java/seedu/sellsavvy/logic/commands/ordercommands/AddOrderCommand.java
@@ -1,5 +1,6 @@
 package seedu.sellsavvy.logic.commands.ordercommands;
 
+import seedu.sellsavvy.commons.core.index.Index;
 import seedu.sellsavvy.commons.util.ToStringBuilder;
 import seedu.sellsavvy.logic.commands.Command;
 import seedu.sellsavvy.logic.commands.CommandResult;
@@ -9,6 +10,7 @@ import seedu.sellsavvy.model.order.Order;
 import seedu.sellsavvy.model.person.Person;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.sellsavvy.commons.util.CollectionUtil.requireAllNonNull;
 import static seedu.sellsavvy.logic.parser.CliSyntax.*;
 
 /**
@@ -32,18 +34,17 @@ public class AddOrderCommand extends Command {
 
     public static final String MESSAGE_SUCCESS = "New Order added under xxx: xxx";
 
-    private final Person personToAddUnder;
+    private final Index index;
 
     private final Order toAdd;
 
     /**
      * Creates an AddOrderCommand to add the specific order under
      */
-    public AddOrderCommand(Person person, Order order) {
-        requireNonNull(person);
-        requireNonNull(order);
-        personToAddUnder = person;
-        toAdd = order;
+    public AddOrderCommand(Index index, Order order) {
+        requireAllNonNull(index, order);
+        this.index = index;
+        this.toAdd = order;
     }
 
     @Override
@@ -66,7 +67,7 @@ public class AddOrderCommand extends Command {
         }
 
         AddOrderCommand otherAddOrderCommand = (AddOrderCommand) other;
-        boolean samePerson = personToAddUnder.equals(otherAddOrderCommand.personToAddUnder);
+        boolean samePerson = index.equals(otherAddOrderCommand.index);
         boolean sameOrder = toAdd.equals(otherAddOrderCommand.toAdd);
         return samePerson && sameOrder;
     }
@@ -74,7 +75,7 @@ public class AddOrderCommand extends Command {
     @Override
     public String toString() {
         return new ToStringBuilder(this)
-                .add("personToAddUnder", personToAddUnder)
+                .add("index", index)
                 .add("toAdd", toAdd)
                 .toString();
     }

--- a/src/main/java/seedu/sellsavvy/logic/commands/ordercommands/AddOrderCommand.java
+++ b/src/main/java/seedu/sellsavvy/logic/commands/ordercommands/AddOrderCommand.java
@@ -1,5 +1,13 @@
 package seedu.sellsavvy.logic.commands.ordercommands;
 
+import static java.util.Objects.requireNonNull;
+import static seedu.sellsavvy.commons.util.CollectionUtil.requireAllNonNull;
+import static seedu.sellsavvy.logic.parser.CliSyntax.PREFIX_COUNT;
+import static seedu.sellsavvy.logic.parser.CliSyntax.PREFIX_DATE;
+import static seedu.sellsavvy.logic.parser.CliSyntax.PREFIX_ITEM;
+
+import java.util.List;
+
 import seedu.sellsavvy.commons.core.index.Index;
 import seedu.sellsavvy.commons.util.ToStringBuilder;
 import seedu.sellsavvy.logic.Messages;
@@ -9,14 +17,6 @@ import seedu.sellsavvy.logic.commands.exceptions.CommandException;
 import seedu.sellsavvy.model.Model;
 import seedu.sellsavvy.model.order.Order;
 import seedu.sellsavvy.model.person.Person;
-
-import java.util.List;
-
-import static java.util.Objects.requireNonNull;
-import static seedu.sellsavvy.commons.util.CollectionUtil.requireAllNonNull;
-import static seedu.sellsavvy.logic.parser.CliSyntax.PREFIX_ITEM;
-import static seedu.sellsavvy.logic.parser.CliSyntax.PREFIX_DATE;
-import static seedu.sellsavvy.logic.parser.CliSyntax.PREFIX_COUNT;
 
 /**
  * Adds an order under a specified person.

--- a/src/main/java/seedu/sellsavvy/logic/commands/ordercommands/AddOrderCommand.java
+++ b/src/main/java/seedu/sellsavvy/logic/commands/ordercommands/AddOrderCommand.java
@@ -16,6 +16,7 @@ import seedu.sellsavvy.logic.commands.CommandResult;
 import seedu.sellsavvy.logic.commands.exceptions.CommandException;
 import seedu.sellsavvy.model.Model;
 import seedu.sellsavvy.model.order.Order;
+import seedu.sellsavvy.model.order.OrderList;
 import seedu.sellsavvy.model.person.Person;
 
 /**
@@ -36,6 +37,9 @@ public class AddOrderCommand extends Command {
             + PREFIX_COUNT + "2";
 
     public static final String MESSAGE_SUCCESS = "New Order added for %1$s: %2$s";
+    public static final String MESSAGE_DUPLICATE_WARNING = "Note: "
+            + "This customer already has an order for this item"
+            + ", verify if this is a mistake\n";
 
     private final Index index;
     private final Order toAdd;
@@ -59,9 +63,11 @@ public class AddOrderCommand extends Command {
         }
 
         Person personToAddUnder = lastShownList.get(index.getZeroBased());
-        personToAddUnder.getOrderList().add(toAdd);
+        OrderList orderList = personToAddUnder.getOrderList();
+        String feedbackToUser = orderList.contains(toAdd) ? MESSAGE_DUPLICATE_WARNING : "";
+        orderList.add(toAdd);
 
-        return new CommandResult(String.format(MESSAGE_SUCCESS,
+        return new CommandResult(feedbackToUser + String.format(MESSAGE_SUCCESS,
                 personToAddUnder.getName(), Messages.format(toAdd)));
     }
 

--- a/src/main/java/seedu/sellsavvy/logic/commands/ordercommands/AddOrderCommand.java
+++ b/src/main/java/seedu/sellsavvy/logic/commands/ordercommands/AddOrderCommand.java
@@ -47,10 +47,10 @@ public class AddOrderCommand extends Command {
     /**
      * Creates an AddOrderCommand to add the specific order under
      */
-    public AddOrderCommand(Index index, Order order) {
-        requireAllNonNull(index, order);
+    public AddOrderCommand(Index index, Order toAdd) {
+        requireAllNonNull(index, toAdd);
         this.index = index;
-        this.toAdd = order;
+        this.toAdd = toAdd;
     }
 
     @Override
@@ -93,7 +93,7 @@ public class AddOrderCommand extends Command {
     public String toString() {
         return new ToStringBuilder(this)
                 .add("index", index)
-                .add("toAdd", toAdd)
+                .add("order", toAdd)
                 .toString();
     }
 }

--- a/src/main/java/seedu/sellsavvy/logic/commands/ordercommands/AddOrderCommand.java
+++ b/src/main/java/seedu/sellsavvy/logic/commands/ordercommands/AddOrderCommand.java
@@ -2,6 +2,7 @@ package seedu.sellsavvy.logic.commands.ordercommands;
 
 import seedu.sellsavvy.commons.core.index.Index;
 import seedu.sellsavvy.commons.util.ToStringBuilder;
+import seedu.sellsavvy.logic.Messages;
 import seedu.sellsavvy.logic.commands.Command;
 import seedu.sellsavvy.logic.commands.CommandResult;
 import seedu.sellsavvy.logic.commands.exceptions.CommandException;
@@ -9,9 +10,13 @@ import seedu.sellsavvy.model.Model;
 import seedu.sellsavvy.model.order.Order;
 import seedu.sellsavvy.model.person.Person;
 
+import java.util.List;
+
 import static java.util.Objects.requireNonNull;
 import static seedu.sellsavvy.commons.util.CollectionUtil.requireAllNonNull;
-import static seedu.sellsavvy.logic.parser.CliSyntax.*;
+import static seedu.sellsavvy.logic.parser.CliSyntax.PREFIX_ITEM;
+import static seedu.sellsavvy.logic.parser.CliSyntax.PREFIX_DATE;
+import static seedu.sellsavvy.logic.parser.CliSyntax.PREFIX_COUNT;
 
 /**
  * Adds an order under a specified person.
@@ -21,21 +26,18 @@ public class AddOrderCommand extends Command {
     public static final String COMMAND_WORD = "addOrder";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds an order under the specified person. "
-            + "Parameters: "
-            + PREFIX_NAME + "NAME "
+            + "Parameters: INDEX (must be a positive integer) "
             + PREFIX_ITEM + "ITEM "
             + PREFIX_DATE + "DELIVERY_BY "
             + PREFIX_COUNT + "ITEM_COUNT\n"
-            + "Example: " + COMMAND_WORD + " "
-            + PREFIX_NAME + "Foo Chao "
+            + "Example: " + COMMAND_WORD + " 1 "
             + PREFIX_ITEM + "Lamp "
             + PREFIX_DATE + "2024-12-20 "
             + PREFIX_COUNT + "2";
 
-    public static final String MESSAGE_SUCCESS = "New Order added under xxx: xxx";
+    public static final String MESSAGE_SUCCESS = "New Order added for %1$s: %2$s";
 
     private final Index index;
-
     private final Order toAdd;
 
     /**
@@ -50,9 +52,17 @@ public class AddOrderCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
+        List<Person> lastShownList = model.getFilteredPersonList();
 
-        // add order in model here
-        return new CommandResult(MESSAGE_SUCCESS);
+        if (index.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        }
+
+        Person personToAddUnder = lastShownList.get(index.getZeroBased());
+        personToAddUnder.getOrderList().add(toAdd);
+
+        return new CommandResult(String.format(MESSAGE_SUCCESS,
+                personToAddUnder.getName(), Messages.format(toAdd)));
     }
 
     @Override
@@ -69,6 +79,7 @@ public class AddOrderCommand extends Command {
         AddOrderCommand otherAddOrderCommand = (AddOrderCommand) other;
         boolean samePerson = index.equals(otherAddOrderCommand.index);
         boolean sameOrder = toAdd.equals(otherAddOrderCommand.toAdd);
+
         return samePerson && sameOrder;
     }
 

--- a/src/main/java/seedu/sellsavvy/logic/commands/ordercommands/AddOrderCommand.java
+++ b/src/main/java/seedu/sellsavvy/logic/commands/ordercommands/AddOrderCommand.java
@@ -1,17 +1,81 @@
 package seedu.sellsavvy.logic.commands.ordercommands;
 
+import seedu.sellsavvy.commons.util.ToStringBuilder;
 import seedu.sellsavvy.logic.commands.Command;
 import seedu.sellsavvy.logic.commands.CommandResult;
 import seedu.sellsavvy.logic.commands.exceptions.CommandException;
 import seedu.sellsavvy.model.Model;
+import seedu.sellsavvy.model.order.Order;
+import seedu.sellsavvy.model.person.Person;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.sellsavvy.logic.parser.CliSyntax.*;
 
 /**
  * Adds an order under a specified person.
  */
 public class AddOrderCommand extends Command {
 
+    public static final String COMMAND_WORD = "addOrder";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds an order under the specified person. "
+            + "Parameters: "
+            + PREFIX_NAME + "NAME "
+            + PREFIX_ITEM + "ITEM "
+            + PREFIX_DATE + "DELIVERY_BY "
+            + PREFIX_COUNT + "ITEM_COUNT\n"
+            + "Example: " + COMMAND_WORD + " "
+            + PREFIX_NAME + "Foo Chao "
+            + PREFIX_ITEM + "Lamp "
+            + PREFIX_DATE + "2024-12-20 "
+            + PREFIX_COUNT + "2";
+
+    public static final String MESSAGE_SUCCESS = "New Order added under xxx: xxx";
+
+    private final Person personToAddUnder;
+
+    private final Order toAdd;
+
+    /**
+     * Creates an AddOrderCommand to add the specific order under
+     */
+    public AddOrderCommand(Person person, Order order) {
+        requireNonNull(person);
+        requireNonNull(order);
+        personToAddUnder = person;
+        toAdd = order;
+    }
+
     @Override
     public CommandResult execute(Model model) throws CommandException {
-        return null; // to be implemented
+        requireNonNull(model);
+
+        // add order in model here
+        return new CommandResult(MESSAGE_SUCCESS);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        //instanceof handles nulls
+        if (!(other instanceof AddOrderCommand)) {
+            return false;
+        }
+
+        AddOrderCommand otherAddOrderCommand = (AddOrderCommand) other;
+        boolean samePerson = personToAddUnder.equals(otherAddOrderCommand.personToAddUnder);
+        boolean sameOrder = toAdd.equals(otherAddOrderCommand.toAdd);
+        return samePerson && sameOrder;
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .add("personToAddUnder", personToAddUnder)
+                .add("toAdd", toAdd)
+                .toString();
     }
 }

--- a/src/main/java/seedu/sellsavvy/logic/commands/ordercommands/AddOrderCommand.java
+++ b/src/main/java/seedu/sellsavvy/logic/commands/ordercommands/AddOrderCommand.java
@@ -33,7 +33,7 @@ public class AddOrderCommand extends Command {
             + PREFIX_COUNT + "ITEM_COUNT\n"
             + "Example: " + COMMAND_WORD + " 1 "
             + PREFIX_ITEM + "Lamp "
-            + PREFIX_DATE + "2024-12-20 "
+            + PREFIX_DATE + "20-12-2024 "
             + PREFIX_COUNT + "2";
 
     public static final String MESSAGE_SUCCESS = "New Order added for %1$s: %2$s";

--- a/src/main/java/seedu/sellsavvy/logic/commands/ordercommands/AddOrderCommand.java
+++ b/src/main/java/seedu/sellsavvy/logic/commands/ordercommands/AddOrderCommand.java
@@ -45,7 +45,10 @@ public class AddOrderCommand extends Command {
     private final Order toAdd;
 
     /**
-     * Creates an AddOrderCommand to add the specific order under
+     * Creates an AddOrderCommand to add the specific order under the specified index.
+     *
+     * @param index of the person in the filtered person list to add order under.
+     * @param toAdd the order made by the person.
      */
     public AddOrderCommand(Index index, Order toAdd) {
         requireAllNonNull(index, toAdd);
@@ -77,16 +80,14 @@ public class AddOrderCommand extends Command {
             return true;
         }
 
-        //instanceof handles nulls
+        // instanceof handles nulls
         if (!(other instanceof AddOrderCommand)) {
             return false;
         }
 
         AddOrderCommand otherAddOrderCommand = (AddOrderCommand) other;
-        boolean samePerson = index.equals(otherAddOrderCommand.index);
-        boolean sameOrder = toAdd.equals(otherAddOrderCommand.toAdd);
-
-        return samePerson && sameOrder;
+        return index.equals(otherAddOrderCommand.index)
+                && toAdd.equals(otherAddOrderCommand.toAdd);
     }
 
     @Override

--- a/src/main/java/seedu/sellsavvy/logic/commands/ordercommands/AddOrderCommand.java
+++ b/src/main/java/seedu/sellsavvy/logic/commands/ordercommands/AddOrderCommand.java
@@ -30,14 +30,14 @@ public class AddOrderCommand extends Command {
             + "Parameters: INDEX (must be a positive integer) "
             + PREFIX_ITEM + "ITEM "
             + PREFIX_DATE + "DELIVERY_BY "
-            + PREFIX_COUNT + "ITEM_COUNT\n"
+            + PREFIX_COUNT + "QUANTITY\n"
             + "Example: " + COMMAND_WORD + " 1 "
             + PREFIX_ITEM + "Lamp "
             + PREFIX_DATE + "20-12-2024 "
             + PREFIX_COUNT + "2";
 
-    public static final String MESSAGE_SUCCESS = "New Order added for %1$s: %2$s";
-    public static final String MESSAGE_DUPLICATE_WARNING = "Note: "
+    public static final String MESSAGE_SUCCESS = "New order added for %1$s: %2$s";
+    public static final String MESSAGE_DUPLICATE_ORDER_WARNING = "Note: "
             + "This customer already has an order for this item"
             + ", verify if this is a mistake\n";
 
@@ -67,7 +67,7 @@ public class AddOrderCommand extends Command {
 
         Person personToAddUnder = lastShownList.get(index.getZeroBased());
         OrderList orderList = personToAddUnder.getOrderList();
-        String feedbackToUser = orderList.contains(toAdd) ? MESSAGE_DUPLICATE_WARNING : "";
+        String feedbackToUser = orderList.contains(toAdd) ? MESSAGE_DUPLICATE_ORDER_WARNING : "";
         orderList.add(toAdd);
 
         return new CommandResult(feedbackToUser + String.format(MESSAGE_SUCCESS,

--- a/src/main/java/seedu/sellsavvy/logic/parser/AddOrderCommandParser.java
+++ b/src/main/java/seedu/sellsavvy/logic/parser/AddOrderCommandParser.java
@@ -41,8 +41,7 @@ public class AddOrderCommandParser implements Parser<AddOrderCommand> {
                     AddOrderCommand.MESSAGE_USAGE), pe);
         }
 
-        if (!arePrefixesPresent(argMultimap, PREFIX_ITEM, PREFIX_DATE, PREFIX_COUNT)
-                || !argMultimap.getPreamble().isEmpty()) {
+        if (!arePrefixesPresent(argMultimap, PREFIX_ITEM, PREFIX_DATE, PREFIX_COUNT)) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddOrderCommand.MESSAGE_USAGE));
         }
 

--- a/src/main/java/seedu/sellsavvy/logic/parser/AddOrderCommandParser.java
+++ b/src/main/java/seedu/sellsavvy/logic/parser/AddOrderCommandParser.java
@@ -1,5 +1,13 @@
 package seedu.sellsavvy.logic.parser;
 
+import static java.util.Objects.requireNonNull;
+import static seedu.sellsavvy.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.sellsavvy.logic.parser.CliSyntax.PREFIX_COUNT;
+import static seedu.sellsavvy.logic.parser.CliSyntax.PREFIX_DATE;
+import static seedu.sellsavvy.logic.parser.CliSyntax.PREFIX_ITEM;
+
+import java.util.stream.Stream;
+
 import seedu.sellsavvy.commons.core.index.Index;
 import seedu.sellsavvy.logic.commands.ordercommands.AddOrderCommand;
 import seedu.sellsavvy.logic.parser.exceptions.ParseException;
@@ -7,14 +15,6 @@ import seedu.sellsavvy.model.order.Count;
 import seedu.sellsavvy.model.order.Date;
 import seedu.sellsavvy.model.order.Item;
 import seedu.sellsavvy.model.order.Order;
-
-import java.util.stream.Stream;
-
-import static java.util.Objects.requireNonNull;
-import static seedu.sellsavvy.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.sellsavvy.logic.parser.CliSyntax.PREFIX_ITEM;
-import static seedu.sellsavvy.logic.parser.CliSyntax.PREFIX_DATE;
-import static seedu.sellsavvy.logic.parser.CliSyntax.PREFIX_COUNT;
 
 /**
  * Parses input arguments and creates a new AddOrderCommand object.

--- a/src/main/java/seedu/sellsavvy/logic/parser/AddOrderCommandParser.java
+++ b/src/main/java/seedu/sellsavvy/logic/parser/AddOrderCommandParser.java
@@ -1,12 +1,66 @@
 package seedu.sellsavvy.logic.parser;
 
+import seedu.sellsavvy.commons.core.index.Index;
 import seedu.sellsavvy.logic.commands.ordercommands.AddOrderCommand;
 import seedu.sellsavvy.logic.parser.exceptions.ParseException;
+import seedu.sellsavvy.model.order.Count;
+import seedu.sellsavvy.model.order.Date;
+import seedu.sellsavvy.model.order.Item;
+import seedu.sellsavvy.model.order.Order;
 
+import java.util.stream.Stream;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.sellsavvy.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.sellsavvy.logic.parser.CliSyntax.PREFIX_ITEM;
+import static seedu.sellsavvy.logic.parser.CliSyntax.PREFIX_DATE;
+import static seedu.sellsavvy.logic.parser.CliSyntax.PREFIX_COUNT;
+
+/**
+ * Parses input arguments and creates a new AddOrderCommand object.
+ */
 public class AddOrderCommandParser implements Parser<AddOrderCommand> {
 
+    /**
+     * Parses the given {@code String} of arguments in the context of the AddOrderCommand
+     * and returns an AddOrderCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
     @Override
-    public AddOrderCommand parse(String userInput) throws ParseException {
-        return null;
+    public AddOrderCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(args, PREFIX_ITEM, PREFIX_DATE, PREFIX_COUNT);
+
+        Index index;
+
+        try {
+            index = ParserUtil.parseIndex(argMultimap.getPreamble());
+        } catch (ParseException pe) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    AddOrderCommand.MESSAGE_USAGE), pe);
+        }
+
+        if (!arePrefixesPresent(argMultimap, PREFIX_ITEM, PREFIX_DATE, PREFIX_COUNT)
+                || !argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddOrderCommand.MESSAGE_USAGE));
+        }
+
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_ITEM, PREFIX_DATE, PREFIX_COUNT);
+        Item item = ParserUtil.parseItem(argMultimap.getValue(PREFIX_ITEM).get());
+        Date date = ParserUtil.parseDate(argMultimap.getValue(PREFIX_DATE).get());
+        Count count = ParserUtil.parseCount(argMultimap.getValue(PREFIX_COUNT).get());
+
+        Order order = new Order(item, count, date);
+
+        return new AddOrderCommand(index, order);
+    }
+
+    /**
+     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
+     * {@code ArgumentMultimap}.
+     */
+    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
     }
 }

--- a/src/main/java/seedu/sellsavvy/logic/parser/AddOrderCommandParser.java
+++ b/src/main/java/seedu/sellsavvy/logic/parser/AddOrderCommandParser.java
@@ -1,0 +1,12 @@
+package seedu.sellsavvy.logic.parser;
+
+import seedu.sellsavvy.logic.commands.ordercommands.AddOrderCommand;
+import seedu.sellsavvy.logic.parser.exceptions.ParseException;
+
+public class AddOrderCommandParser implements Parser<AddOrderCommand> {
+
+    @Override
+    public AddOrderCommand parse(String userInput) throws ParseException {
+        return null;
+    }
+}

--- a/src/main/java/seedu/sellsavvy/logic/parser/AddOrderCommandParser.java
+++ b/src/main/java/seedu/sellsavvy/logic/parser/AddOrderCommandParser.java
@@ -22,9 +22,9 @@ import seedu.sellsavvy.model.order.Order;
 public class AddOrderCommandParser implements Parser<AddOrderCommand> {
 
     /**
-     * Parses the given {@code String} of arguments in the context of the AddOrderCommand
+     * Parses the given {@code String} of arguments in the context of the AddOrderCommand.
      * and returns an AddOrderCommand object for execution.
-     * @throws ParseException if the user input does not conform the expected format
+     * @throws ParseException if the user input does not conform the expected format.
      */
     @Override
     public AddOrderCommand parse(String args) throws ParseException {
@@ -57,7 +57,7 @@ public class AddOrderCommandParser implements Parser<AddOrderCommand> {
     }
 
     /**
-     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
+     * Returns true if none of the prefixes contains empty {@code Optional} values in the given.
      * {@code ArgumentMultimap}.
      */
     private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {

--- a/src/main/java/seedu/sellsavvy/logic/parser/AddOrderCommandParser.java
+++ b/src/main/java/seedu/sellsavvy/logic/parser/AddOrderCommandParser.java
@@ -34,15 +34,16 @@ public class AddOrderCommandParser implements Parser<AddOrderCommand> {
 
         Index index;
 
+        if (!arePrefixesPresent(argMultimap, PREFIX_ITEM, PREFIX_DATE, PREFIX_COUNT)
+                || argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddOrderCommand.MESSAGE_USAGE));
+        }
+
         try {
             index = ParserUtil.parseIndex(argMultimap.getPreamble());
         } catch (ParseException pe) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                     AddOrderCommand.MESSAGE_USAGE), pe);
-        }
-
-        if (!arePrefixesPresent(argMultimap, PREFIX_ITEM, PREFIX_DATE, PREFIX_COUNT)) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddOrderCommand.MESSAGE_USAGE));
         }
 
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_ITEM, PREFIX_DATE, PREFIX_COUNT);

--- a/src/main/java/seedu/sellsavvy/logic/parser/AddPersonCommandParser.java
+++ b/src/main/java/seedu/sellsavvy/logic/parser/AddPersonCommandParser.java
@@ -21,7 +21,7 @@ import seedu.sellsavvy.model.person.Phone;
 import seedu.sellsavvy.model.tag.Tag;
 
 /**
- * Parses input arguments and creates a new AddPersonCommand object
+ * Parses input arguments and creates a new AddPersonCommand object.
  */
 public class AddPersonCommandParser implements Parser<AddPersonCommand> {
 

--- a/src/main/java/seedu/sellsavvy/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/sellsavvy/logic/parser/AddressBookParser.java
@@ -12,6 +12,7 @@ import seedu.sellsavvy.logic.commands.Command;
 import seedu.sellsavvy.logic.commands.generalcommands.ClearCommand;
 import seedu.sellsavvy.logic.commands.generalcommands.ExitCommand;
 import seedu.sellsavvy.logic.commands.generalcommands.HelpCommand;
+import seedu.sellsavvy.logic.commands.ordercommands.AddOrderCommand;
 import seedu.sellsavvy.logic.commands.personcommands.AddPersonCommand;
 import seedu.sellsavvy.logic.commands.personcommands.DeletePersonCommand;
 import seedu.sellsavvy.logic.commands.personcommands.EditPersonCommand;
@@ -76,6 +77,9 @@ public class AddressBookParser {
 
         case HelpCommand.COMMAND_WORD:
             return new HelpCommand();
+
+        case AddOrderCommand.COMMAND_WORD:
+            return new AddOrderCommandParser().parse(arguments);
 
         default:
             logger.finer("This user input caused a ParseException: " + userInput);

--- a/src/main/java/seedu/sellsavvy/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/sellsavvy/logic/parser/CliSyntax.java
@@ -1,7 +1,7 @@
 package seedu.sellsavvy.logic.parser;
 
 /**
- * Contains Command Line Interface (CLI) syntax definitions common to multiple commands
+ * Contains Command Line Interface (CLI) syntax definitions common to multiple commands.
  */
 public class CliSyntax {
 

--- a/src/main/java/seedu/sellsavvy/logic/parser/DeletePersonCommandParser.java
+++ b/src/main/java/seedu/sellsavvy/logic/parser/DeletePersonCommandParser.java
@@ -7,7 +7,7 @@ import seedu.sellsavvy.logic.commands.personcommands.DeletePersonCommand;
 import seedu.sellsavvy.logic.parser.exceptions.ParseException;
 
 /**
- * Parses input arguments and creates a new DeletePersonCommand object
+ * Parses input arguments and creates a new DeletePersonCommand object.
  */
 public class DeletePersonCommandParser implements Parser<DeletePersonCommand> {
 

--- a/src/main/java/seedu/sellsavvy/logic/parser/EditPersonCommandParser.java
+++ b/src/main/java/seedu/sellsavvy/logic/parser/EditPersonCommandParser.java
@@ -20,7 +20,7 @@ import seedu.sellsavvy.logic.parser.exceptions.ParseException;
 import seedu.sellsavvy.model.tag.Tag;
 
 /**
- * Parses input arguments and creates a new EditPersonCommand object
+ * Parses input arguments and creates a new EditPersonCommand object.
  */
 public class EditPersonCommandParser implements Parser<EditPersonCommand> {
 

--- a/src/main/java/seedu/sellsavvy/logic/parser/FindPersonCommandParser.java
+++ b/src/main/java/seedu/sellsavvy/logic/parser/FindPersonCommandParser.java
@@ -9,7 +9,7 @@ import seedu.sellsavvy.logic.parser.exceptions.ParseException;
 import seedu.sellsavvy.model.person.NameContainsKeywordsPredicate;
 
 /**
- * Parses input arguments and creates a new FindPersonCommand object
+ * Parses input arguments and creates a new FindPersonCommand object.
  */
 public class FindPersonCommandParser implements Parser<FindPersonCommand> {
 

--- a/src/main/java/seedu/sellsavvy/model/AddressBook.java
+++ b/src/main/java/seedu/sellsavvy/model/AddressBook.java
@@ -127,4 +127,13 @@ public class AddressBook implements ReadOnlyAddressBook {
     public int hashCode() {
         return persons.hashCode();
     }
+
+    /**
+     * Creates a copy of all data in this {@code AddressBook}.
+     */
+    public AddressBook createCopy() {
+        AddressBook newAddressBook = new AddressBook();
+        newAddressBook.setPersons(persons.copyPersons().asUnmodifiableObservableList());
+        return newAddressBook;
+    }
 }

--- a/src/main/java/seedu/sellsavvy/model/Model.java
+++ b/src/main/java/seedu/sellsavvy/model/Model.java
@@ -80,6 +80,11 @@ public interface Model {
     ObservableList<Person> getFilteredPersonList();
 
     /**
+     * Creates a copy of the entire {@code Model}.
+     */
+    Model createCopy();
+
+    /**
      * Updates the filter of the filtered person list to filter by the given {@code predicate}.
      * @throws NullPointerException if {@code predicate} is null.
      */

--- a/src/main/java/seedu/sellsavvy/model/ModelManager.java
+++ b/src/main/java/seedu/sellsavvy/model/ModelManager.java
@@ -111,6 +111,11 @@ public class ModelManager implements Model {
         addressBook.setPerson(target, editedPerson);
     }
 
+    @Override
+    public Model createCopy() {
+        return new ModelManager(addressBook.createCopy(), userPrefs);
+    }
+
     //=========== Filtered Person List Accessors =============================================================
 
     /**

--- a/src/main/java/seedu/sellsavvy/model/person/Person.java
+++ b/src/main/java/seedu/sellsavvy/model/person/Person.java
@@ -100,7 +100,8 @@ public class Person {
                 && phone.equals(otherPerson.phone)
                 && email.equals(otherPerson.email)
                 && address.equals(otherPerson.address)
-                && tags.equals(otherPerson.tags);
+                && tags.equals(otherPerson.tags)
+                && orders.equals(otherPerson.orders);
     }
 
     @Override

--- a/src/main/java/seedu/sellsavvy/model/person/UniquePersonList.java
+++ b/src/main/java/seedu/sellsavvy/model/person/UniquePersonList.java
@@ -5,11 +5,14 @@ import static seedu.sellsavvy.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.util.Iterator;
 import java.util.List;
+import java.util.Set;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
+import seedu.sellsavvy.model.order.*;
 import seedu.sellsavvy.model.person.exceptions.DuplicatePersonException;
 import seedu.sellsavvy.model.person.exceptions.PersonNotFoundException;
+import seedu.sellsavvy.model.tag.Tag;
 
 /**
  * A list of persons that enforces uniqueness between its elements and does not allow nulls.
@@ -98,6 +101,17 @@ public class UniquePersonList implements Iterable<Person> {
     }
 
     /**
+     * Creates a {@code UniquePersonList} copy of all data in this list.
+     */
+    public UniquePersonList copyPersons() {
+        UniquePersonList copy = new UniquePersonList();
+        for (Person person : internalList) {
+            copy.add(copyPerson(person));
+        }
+        return copy;
+    }
+
+    /**
      * Returns the backing list as an unmodifiable {@code ObservableList}.
      */
     public ObservableList<Person> asUnmodifiableObservableList() {
@@ -146,5 +160,32 @@ public class UniquePersonList implements Iterable<Person> {
             }
         }
         return true;
+    }
+
+    /**
+     * Creates a new copy of {@code Person} with new attributes.
+     * Only the tags are not copied.
+     */
+    private Person copyPerson(Person person) {
+        Name name = new Name(person.getName().toString());
+        Address address = new Address(person.getAddress().toString());
+        Phone phone = new Phone(person.getPhone().toString());
+        Email email = new Email(person.getEmail().toString());
+        Set<Tag> tags = person.getTags();
+        OrderList orderList = new OrderList();
+        for (Order order : person.getOrderList()) {
+            orderList.add(copyOrder(order));
+        }
+        return new Person(name, phone, email, address, tags, orderList);
+    }
+
+    /**
+     * Creates a new copy of {@code Order} with new attributes.
+     */
+    private Order copyOrder(Order order) {
+        Item item = new Item(order.getItem().toString());
+        Date date = new Date(order.getDate().toString());
+        Count count = new Count(order.getCount().toString());
+        return new Order(item, count, date);
     }
 }

--- a/src/main/java/seedu/sellsavvy/model/person/UniquePersonList.java
+++ b/src/main/java/seedu/sellsavvy/model/person/UniquePersonList.java
@@ -9,7 +9,11 @@ import java.util.Set;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
-import seedu.sellsavvy.model.order.*;
+import seedu.sellsavvy.model.order.Count;
+import seedu.sellsavvy.model.order.Date;
+import seedu.sellsavvy.model.order.Item;
+import seedu.sellsavvy.model.order.Order;
+import seedu.sellsavvy.model.order.OrderList;
 import seedu.sellsavvy.model.person.exceptions.DuplicatePersonException;
 import seedu.sellsavvy.model.person.exceptions.PersonNotFoundException;
 import seedu.sellsavvy.model.tag.Tag;

--- a/src/test/java/seedu/sellsavvy/logic/commands/ordercommands/AddOrderCommandTest.java
+++ b/src/test/java/seedu/sellsavvy/logic/commands/ordercommands/AddOrderCommandTest.java
@@ -1,11 +1,15 @@
 package seedu.sellsavvy.logic.commands.ordercommands;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static seedu.sellsavvy.logic.commands.ordercommands.AddOrderCommand.MESSAGE_DUPLICATE_WARNING;
 import static seedu.sellsavvy.logic.commands.ordercommands.OrderCommandTestUtil.assertCommandFailure;
 import static seedu.sellsavvy.logic.commands.ordercommands.OrderCommandTestUtil.assertCommandSuccess;
 import static seedu.sellsavvy.logic.commands.personcommands.PersonCommandTestUtil.showPersonAtIndex;
 import static seedu.sellsavvy.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.sellsavvy.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
 import static seedu.sellsavvy.testutil.TypicalOrders.ABACUS;
 import static seedu.sellsavvy.testutil.TypicalOrders.BLOCKS;
 import static seedu.sellsavvy.testutil.TypicalPersons.getTypicalAddressBook;
@@ -101,5 +105,33 @@ public class AddOrderCommandTest {
         AddOrderCommand addOrderCommand = new AddOrderCommand(outOfBoundIndex, ABACUS);
 
         assertCommandFailure(addOrderCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void equals() {
+        final AddOrderCommand standardCommand = new AddOrderCommand(INDEX_FIRST_PERSON, ABACUS);
+
+        // same object -> returns true
+        assertTrue(standardCommand.equals(standardCommand));
+
+        // same values -> returns true
+        assertTrue(standardCommand.equals(new AddOrderCommand(INDEX_FIRST_PERSON, ABACUS)));
+
+        // null -> returns false
+        assertFalse(standardCommand.equals(null));
+
+        // different Index -> returns false
+        assertFalse(standardCommand.equals(new AddOrderCommand(INDEX_SECOND_PERSON, ABACUS)));
+
+        // different item -> returns false
+        assertFalse(standardCommand.equals(new AddOrderCommand(INDEX_FIRST_PERSON, BLOCKS)));
+    }
+
+    @Test
+    public void toStringMethod() {
+        AddOrderCommand addOrderCommand = new AddOrderCommand(INDEX_FIRST_PERSON, ABACUS);
+        String expected = AddOrderCommand.class.getCanonicalName()
+                + "{index=" + INDEX_FIRST_PERSON + ", order=" + ABACUS + "}";
+        assertEquals(expected, addOrderCommand.toString());
     }
 }

--- a/src/test/java/seedu/sellsavvy/logic/commands/ordercommands/AddOrderCommandTest.java
+++ b/src/test/java/seedu/sellsavvy/logic/commands/ordercommands/AddOrderCommandTest.java
@@ -5,7 +5,7 @@ import org.junit.jupiter.api.Test;
 import seedu.sellsavvy.model.Model;
 import seedu.sellsavvy.model.ModelManager;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class AddOrderCommandTest {
 

--- a/src/test/java/seedu/sellsavvy/logic/commands/ordercommands/AddOrderCommandTest.java
+++ b/src/test/java/seedu/sellsavvy/logic/commands/ordercommands/AddOrderCommandTest.java
@@ -1,13 +1,21 @@
 package seedu.sellsavvy.logic.commands.ordercommands;
 
+import static org.junit.jupiter.api.Assertions.fail;
+import static seedu.sellsavvy.logic.commands.ordercommands.AddOrderCommand.MESSAGE_DUPLICATE_WARNING;
+import static seedu.sellsavvy.logic.commands.ordercommands.OrderCommandTestUtil.assertCommandFailure;
 import static seedu.sellsavvy.logic.commands.ordercommands.OrderCommandTestUtil.assertCommandSuccess;
+import static seedu.sellsavvy.logic.commands.personcommands.PersonCommandTestUtil.showPersonAtIndex;
 import static seedu.sellsavvy.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.sellsavvy.testutil.TypicalOrders.ABACUS;
+import static seedu.sellsavvy.testutil.TypicalOrders.BLOCKS;
 import static seedu.sellsavvy.testutil.TypicalPersons.getTypicalAddressBook;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import seedu.sellsavvy.commons.core.index.Index;
 import seedu.sellsavvy.logic.Messages;
+import seedu.sellsavvy.logic.commands.exceptions.CommandException;
 import seedu.sellsavvy.model.Model;
 import seedu.sellsavvy.model.ModelManager;
 import seedu.sellsavvy.model.UserPrefs;
@@ -15,18 +23,83 @@ import seedu.sellsavvy.model.person.Person;
 
 public class AddOrderCommandTest {
 
-    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+    private Model model;
+
+    @BeforeEach
+    public void setUp() {
+        model = new ModelManager(getTypicalAddressBook(), new UserPrefs()).createCopy();
+    }
 
     @Test
-    public void execute_newOrder_success() {
+    public void execute_validPersonIndexUnfilteredList_success() {
+        AddOrderCommand addFirstOrder = new AddOrderCommand(INDEX_FIRST_PERSON, ABACUS);
+
+        Model expectedModel = model.createCopy();
+        Person personToAddUnder = expectedModel.getFilteredPersonList().get(0);
+        String firstExpectedMessage = String.format(AddOrderCommand.MESSAGE_SUCCESS,
+                personToAddUnder.getName(), Messages.format(ABACUS));
+        personToAddUnder.getOrderList().add(ABACUS);
+
+        // First order
+        assertCommandSuccess(addFirstOrder, model, firstExpectedMessage, expectedModel);
+
+        // Second order
+        AddOrderCommand addSecondOrder = new AddOrderCommand(INDEX_FIRST_PERSON, BLOCKS);
+        String secondExpectedMessage = String.format(AddOrderCommand.MESSAGE_SUCCESS,
+                personToAddUnder.getName(), Messages.format(BLOCKS));
+        personToAddUnder.getOrderList().add(BLOCKS);
+
+        assertCommandSuccess(addSecondOrder, model, secondExpectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_duplicateOrder_warningGiven() {
         AddOrderCommand addOrderCommand = new AddOrderCommand(INDEX_FIRST_PERSON, ABACUS);
 
-        Model expectedModel = new ModelManager(getTypicalAddressBook().createCopy(), new UserPrefs());
+        try {
+            addOrderCommand.execute(model);
+
+            Model expectedModel = model.createCopy();
+            Person personToAddUnder = expectedModel.getFilteredPersonList().get(0);
+            personToAddUnder.getOrderList().add(ABACUS);
+            String expectedMessage = String.format(MESSAGE_DUPLICATE_WARNING + AddOrderCommand.MESSAGE_SUCCESS,
+                    personToAddUnder.getName(), Messages.format(ABACUS));
+
+            assertCommandSuccess(addOrderCommand, model, expectedMessage, expectedModel);
+        } catch (CommandException ce) {
+            fail();
+        }
+    }
+
+    @Test
+    public void execute_invalidPersonIndexUnfilteredList_failure() {
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
+        AddOrderCommand addOrderCommand = new AddOrderCommand(outOfBoundIndex, ABACUS);
+
+        assertCommandFailure(addOrderCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void execute_validPersonIndexFilteredList_success() {
+        showPersonAtIndex(model, INDEX_FIRST_PERSON);
+        AddOrderCommand addOrderCommand = new AddOrderCommand(INDEX_FIRST_PERSON, ABACUS);
+
+        Model expectedModel = model.createCopy();
+        showPersonAtIndex(expectedModel, INDEX_FIRST_PERSON);
         Person personToAddUnder = expectedModel.getFilteredPersonList().get(0);
         String expectedMessage = String.format(AddOrderCommand.MESSAGE_SUCCESS,
                 personToAddUnder.getName(), Messages.format(ABACUS));
         personToAddUnder.getOrderList().add(ABACUS);
 
         assertCommandSuccess(addOrderCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void executeInvalidPersonIndexFilteredList_failure() {
+        showPersonAtIndex(model, INDEX_FIRST_PERSON);
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
+        AddOrderCommand addOrderCommand = new AddOrderCommand(outOfBoundIndex, ABACUS);
+
+        assertCommandFailure(addOrderCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
     }
 }

--- a/src/test/java/seedu/sellsavvy/logic/commands/ordercommands/AddOrderCommandTest.java
+++ b/src/test/java/seedu/sellsavvy/logic/commands/ordercommands/AddOrderCommandTest.java
@@ -1,18 +1,32 @@
 package seedu.sellsavvy.logic.commands.ordercommands;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static seedu.sellsavvy.logic.commands.personcommands.PersonCommandTestUtil.assertCommandSuccess;
+import static seedu.sellsavvy.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.sellsavvy.testutil.TypicalOrders.ABACUS;
+import static seedu.sellsavvy.testutil.TypicalPersons.getTypicalAddressBook;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.sellsavvy.logic.Messages;
 import seedu.sellsavvy.model.Model;
 import seedu.sellsavvy.model.ModelManager;
+import seedu.sellsavvy.model.UserPrefs;
+import seedu.sellsavvy.model.person.Person;
 
 public class AddOrderCommandTest {
 
-    //TODO: Remove this
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
     @Test
-    public void execute_newOrder_success() { // not a legit test
-        Model model = new ModelManager();
-        assertThrows(NullPointerException.class, () -> new AddOrderCommand(null, null).execute(model));
+    public void execute_newOrder_success() {
+        AddOrderCommand addOrderCommand = new AddOrderCommand(INDEX_FIRST_PERSON, ABACUS);
+
+        Model expectedModel = new ModelManager(getTypicalAddressBook().createCopy(), new UserPrefs());
+        Person personToAddUnder = expectedModel.getFilteredPersonList().get(0);
+        String expectedMessage = String.format(AddOrderCommand.MESSAGE_SUCCESS,
+                personToAddUnder.getName(), Messages.format(ABACUS));
+        personToAddUnder.getOrderList().add(ABACUS);
+
+        assertCommandSuccess(addOrderCommand, model, expectedMessage, expectedModel);
     }
 }

--- a/src/test/java/seedu/sellsavvy/logic/commands/ordercommands/AddOrderCommandTest.java
+++ b/src/test/java/seedu/sellsavvy/logic/commands/ordercommands/AddOrderCommandTest.java
@@ -1,11 +1,11 @@
 package seedu.sellsavvy.logic.commands.ordercommands;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import org.junit.jupiter.api.Test;
 
 import seedu.sellsavvy.model.Model;
 import seedu.sellsavvy.model.ModelManager;
-
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class AddOrderCommandTest {
 

--- a/src/test/java/seedu/sellsavvy/logic/commands/ordercommands/AddOrderCommandTest.java
+++ b/src/test/java/seedu/sellsavvy/logic/commands/ordercommands/AddOrderCommandTest.java
@@ -1,6 +1,6 @@
 package seedu.sellsavvy.logic.commands.ordercommands;
 
-import static seedu.sellsavvy.logic.commands.personcommands.PersonCommandTestUtil.assertCommandSuccess;
+import static seedu.sellsavvy.logic.commands.ordercommands.OrderCommandTestUtil.assertCommandSuccess;
 import static seedu.sellsavvy.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.sellsavvy.testutil.TypicalOrders.ABACUS;
 import static seedu.sellsavvy.testutil.TypicalPersons.getTypicalAddressBook;

--- a/src/test/java/seedu/sellsavvy/logic/commands/ordercommands/AddOrderCommandTest.java
+++ b/src/test/java/seedu/sellsavvy/logic/commands/ordercommands/AddOrderCommandTest.java
@@ -1,12 +1,11 @@
 package seedu.sellsavvy.logic.commands.ordercommands;
 
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.fail;
-
 import org.junit.jupiter.api.Test;
 
 import seedu.sellsavvy.model.Model;
 import seedu.sellsavvy.model.ModelManager;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class AddOrderCommandTest {
 
@@ -14,10 +13,6 @@ public class AddOrderCommandTest {
     @Test
     public void execute_newOrder_success() { // not a legit test
         Model model = new ModelManager();
-        try {
-            assertNull(new AddOrderCommand().execute(model));
-        } catch (Exception e) {
-            fail();
-        }
+        assertThrows(NullPointerException.class, () -> new AddOrderCommand(null, null).execute(model));
     }
 }

--- a/src/test/java/seedu/sellsavvy/logic/commands/ordercommands/AddOrderCommandTest.java
+++ b/src/test/java/seedu/sellsavvy/logic/commands/ordercommands/AddOrderCommandTest.java
@@ -4,7 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
-import static seedu.sellsavvy.logic.commands.ordercommands.AddOrderCommand.MESSAGE_DUPLICATE_WARNING;
+import static seedu.sellsavvy.logic.commands.ordercommands.AddOrderCommand.MESSAGE_DUPLICATE_ORDER_WARNING;
 import static seedu.sellsavvy.logic.commands.ordercommands.OrderCommandTestUtil.assertCommandFailure;
 import static seedu.sellsavvy.logic.commands.ordercommands.OrderCommandTestUtil.assertCommandSuccess;
 import static seedu.sellsavvy.logic.commands.personcommands.PersonCommandTestUtil.showPersonAtIndex;
@@ -66,7 +66,7 @@ public class AddOrderCommandTest {
             Model expectedModel = model.createCopy();
             Person personToAddUnder = expectedModel.getFilteredPersonList().get(0);
             personToAddUnder.getOrderList().add(ABACUS);
-            String expectedMessage = String.format(MESSAGE_DUPLICATE_WARNING + AddOrderCommand.MESSAGE_SUCCESS,
+            String expectedMessage = String.format(MESSAGE_DUPLICATE_ORDER_WARNING + AddOrderCommand.MESSAGE_SUCCESS,
                     personToAddUnder.getName(), Messages.format(ABACUS));
 
             assertCommandSuccess(addOrderCommand, model, expectedMessage, expectedModel);

--- a/src/test/java/seedu/sellsavvy/logic/commands/ordercommands/OrderCommandTestUtil.java
+++ b/src/test/java/seedu/sellsavvy/logic/commands/ordercommands/OrderCommandTestUtil.java
@@ -1,9 +1,15 @@
 package seedu.sellsavvy.logic.commands.ordercommands;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import seedu.sellsavvy.commons.core.index.Index;
 import seedu.sellsavvy.logic.commands.Command;
 import seedu.sellsavvy.logic.commands.CommandResult;
+import seedu.sellsavvy.logic.commands.exceptions.CommandException;
+import seedu.sellsavvy.model.AddressBook;
 import seedu.sellsavvy.model.Model;
+import seedu.sellsavvy.model.ModelManager;
+import seedu.sellsavvy.model.UserPrefs;
 
 /**
  * Contains helper methods for testing Order commands.
@@ -17,24 +23,35 @@ public class OrderCommandTestUtil {
     public static final String VALID_ITEM_ATLAS = "Atlas A";
     public static final String VALID_ITEM_BOTTLE = "Bottle B";
 
-    //TODO: Copy data fields from PersonCommandTestUtil
-
-    //TODO:
     /**
      * Executes the given {@code command}, confirms that <br>
      * - the returned {@link CommandResult} matches {@code expectedCommandResult} <br>
      * - the {@code actualModel} matches {@code expectedModel}
      */
     public static void assertCommandSuccess(Command command, Model actualModel, CommandResult expectedCommandResult,
-            Model expectedModel) {}
+            Model expectedModel) {
+        try {
+            AddressBook actualAddressBook = (AddressBook) actualModel.getAddressBook();
+            Model actualModelCopy = new ModelManager(actualAddressBook.createCopy(), new UserPrefs());
+            CommandResult result = command.execute(actualModelCopy);
+            assertEquals(expectedCommandResult, result);
+            assertEquals(expectedModel, actualModelCopy);
+        } catch (CommandException ce) {
+            throw new AssertionError("Execution of command should not fail.", ce);
+        }
+    }
 
-    //TODO:
     /**
      * Convenience wrapper to {@link #assertCommandSuccess(Command, Model, CommandResult, Model)}
      * that takes a string {@code expectedMessage}.
      */
     public static void assertCommandSuccess(Command command, Model actualModel, String expectedMessage,
-            Model expectedModel) {}
+            Model expectedModel) {
+        CommandResult expectedCommandResult = new CommandResult(expectedMessage);
+        assertCommandSuccess(command, actualModel, expectedCommandResult, expectedModel);
+    }
+
+    //TODO: Copy data fields from PersonCommandTestUtil
 
     //TODO:
     /**

--- a/src/test/java/seedu/sellsavvy/logic/commands/ordercommands/OrderCommandTestUtil.java
+++ b/src/test/java/seedu/sellsavvy/logic/commands/ordercommands/OrderCommandTestUtil.java
@@ -2,6 +2,9 @@ package seedu.sellsavvy.logic.commands.ordercommands;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.sellsavvy.logic.parser.CliSyntax.PREFIX_COUNT;
+import static seedu.sellsavvy.logic.parser.CliSyntax.PREFIX_DATE;
+import static seedu.sellsavvy.logic.parser.CliSyntax.PREFIX_ITEM;
 import static seedu.sellsavvy.testutil.Assert.assertThrows;
 
 import java.util.ArrayList;
@@ -28,6 +31,22 @@ public class OrderCommandTestUtil {
     public static final String VALID_DATE_BOTTLE = "05-06-2027";
     public static final String VALID_ITEM_ATLAS = "Atlas A";
     public static final String VALID_ITEM_BOTTLE = "Bottle B";
+
+    public static final String COUNT_DESC_ATLAS = " " + PREFIX_COUNT + VALID_COUNT_ATLAS;
+    public static final String COUNT_DESC_BOTTLE = " " + PREFIX_COUNT + VALID_COUNT_BOTTLE;
+    public static final String DATE_DESC_ATLAS = " " + PREFIX_DATE + VALID_DATE_ATLAS;
+    public static final String DATE_DESC_BOTTLE = " " + PREFIX_DATE + VALID_DATE_BOTTLE;
+    public static final String ITEM_DESC_ATLAS = " " + PREFIX_ITEM + VALID_ITEM_ATLAS;
+    public static final String ITEM_DESC_BOTTLE = " " + PREFIX_ITEM + VALID_ITEM_BOTTLE;
+
+    public static final String INVALID_ITEM_DESC = " " + PREFIX_ITEM + "Atlas&";
+    public static final String INVALID_DATE_DESC = " " + PREFIX_DATE + "a";
+    public static final String INVALID_DATE_NO_HYPHEN = " " + PREFIX_DATE + "02/12/2024";
+    public static final String INVALID_DATE_DIGIT = " " + PREFIX_DATE + "2/1/2024";
+    public static final String INVALID_DATE_VALUE = " " + PREFIX_DATE + "32-01-2024";
+    public static final String INVALID_COUNT_ZERO = " " + PREFIX_COUNT + "0";
+    public static final String INVALID_COUNT_NEGATIVE = " " + PREFIX_COUNT + "-2";
+    public static final String INVALID_COUNT_STRING = " " + PREFIX_COUNT + "2 some random string";
 
     /**
      * Executes the given {@code command}, confirms that <br>

--- a/src/test/java/seedu/sellsavvy/logic/commands/personcommands/AddPersonCommandTest.java
+++ b/src/test/java/seedu/sellsavvy/logic/commands/personcommands/AddPersonCommandTest.java
@@ -151,6 +151,11 @@ public class AddPersonCommandTest {
         }
 
         @Override
+        public Model createCopy() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public ObservableList<Person> getFilteredPersonList() {
             throw new AssertionError("This method should not be called.");
         }

--- a/src/test/java/seedu/sellsavvy/logic/parser/AddOrderCommandParserTest.java
+++ b/src/test/java/seedu/sellsavvy/logic/parser/AddOrderCommandParserTest.java
@@ -1,10 +1,11 @@
 package seedu.sellsavvy.logic.parser;
 
-import org.junit.jupiter.api.Test;
-import seedu.sellsavvy.logic.commands.ordercommands.AddOrderCommand;
-
 import static seedu.sellsavvy.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.sellsavvy.logic.parser.CommandParserTestUtil.assertParseFailure;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.sellsavvy.logic.commands.ordercommands.AddOrderCommand;
 
 public class AddOrderCommandParserTest {
 

--- a/src/test/java/seedu/sellsavvy/logic/parser/AddOrderCommandParserTest.java
+++ b/src/test/java/seedu/sellsavvy/logic/parser/AddOrderCommandParserTest.java
@@ -1,0 +1,19 @@
+package seedu.sellsavvy.logic.parser;
+
+import org.junit.jupiter.api.Test;
+import seedu.sellsavvy.logic.commands.ordercommands.AddOrderCommand;
+
+import static seedu.sellsavvy.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.sellsavvy.logic.parser.CommandParserTestUtil.assertParseFailure;
+
+public class AddOrderCommandParserTest {
+
+    private AddOrderCommandParser parser = new AddOrderCommandParser();
+
+    // TODO: Update tests when implementation is done
+    @Test
+    public void parseAllFieldsPresent_success() { // dummy test
+        assertParseFailure(parser, "",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddOrderCommand.MESSAGE_USAGE));
+    }
+}

--- a/src/test/java/seedu/sellsavvy/logic/parser/AddOrderCommandParserTest.java
+++ b/src/test/java/seedu/sellsavvy/logic/parser/AddOrderCommandParserTest.java
@@ -1,20 +1,204 @@
 package seedu.sellsavvy.logic.parser;
 
 import static seedu.sellsavvy.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.sellsavvy.logic.commands.ordercommands.OrderCommandTestUtil.COUNT_DESC_ATLAS;
+import static seedu.sellsavvy.logic.commands.ordercommands.OrderCommandTestUtil.COUNT_DESC_BOTTLE;
+import static seedu.sellsavvy.logic.commands.ordercommands.OrderCommandTestUtil.DATE_DESC_ATLAS;
+import static seedu.sellsavvy.logic.commands.ordercommands.OrderCommandTestUtil.DATE_DESC_BOTTLE;
+import static seedu.sellsavvy.logic.commands.ordercommands.OrderCommandTestUtil.INVALID_COUNT_NEGATIVE;
+import static seedu.sellsavvy.logic.commands.ordercommands.OrderCommandTestUtil.INVALID_COUNT_STRING;
+import static seedu.sellsavvy.logic.commands.ordercommands.OrderCommandTestUtil.INVALID_COUNT_ZERO;
+import static seedu.sellsavvy.logic.commands.ordercommands.OrderCommandTestUtil.INVALID_DATE_DESC;
+import static seedu.sellsavvy.logic.commands.ordercommands.OrderCommandTestUtil.INVALID_DATE_DIGIT;
+import static seedu.sellsavvy.logic.commands.ordercommands.OrderCommandTestUtil.INVALID_DATE_NO_HYPHEN;
+import static seedu.sellsavvy.logic.commands.ordercommands.OrderCommandTestUtil.INVALID_DATE_VALUE;
+import static seedu.sellsavvy.logic.commands.ordercommands.OrderCommandTestUtil.INVALID_ITEM_DESC;
+import static seedu.sellsavvy.logic.commands.ordercommands.OrderCommandTestUtil.ITEM_DESC_ATLAS;
+import static seedu.sellsavvy.logic.commands.ordercommands.OrderCommandTestUtil.ITEM_DESC_BOTTLE;
+import static seedu.sellsavvy.logic.commands.ordercommands.OrderCommandTestUtil.VALID_COUNT_ATLAS;
+import static seedu.sellsavvy.logic.commands.ordercommands.OrderCommandTestUtil.VALID_DATE_ATLAS;
+import static seedu.sellsavvy.logic.commands.ordercommands.OrderCommandTestUtil.VALID_ITEM_ATLAS;
+import static seedu.sellsavvy.logic.parser.CliSyntax.PREFIX_COUNT;
+import static seedu.sellsavvy.logic.parser.CliSyntax.PREFIX_DATE;
+import static seedu.sellsavvy.logic.parser.CliSyntax.PREFIX_ITEM;
 import static seedu.sellsavvy.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.sellsavvy.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.sellsavvy.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.sellsavvy.testutil.TypicalOrders.ATLAS;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.sellsavvy.commons.core.index.Index;
+import seedu.sellsavvy.logic.Messages;
 import seedu.sellsavvy.logic.commands.ordercommands.AddOrderCommand;
+import seedu.sellsavvy.model.order.Count;
+import seedu.sellsavvy.model.order.Date;
+import seedu.sellsavvy.model.order.Item;
 
 public class AddOrderCommandParserTest {
 
+    private static final String MESSAGE_INVALID_FORMAT =
+            String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddOrderCommand.MESSAGE_USAGE);
+    private static final String VALID_ORDER_STRING = ITEM_DESC_ATLAS + DATE_DESC_ATLAS + COUNT_DESC_ATLAS;
     private AddOrderCommandParser parser = new AddOrderCommandParser();
 
-    // TODO: Update tests when implementation is done
     @Test
-    public void parseAllFieldsPresent_success() { // dummy test
-        assertParseFailure(parser, "",
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddOrderCommand.MESSAGE_USAGE));
+    public void parse_allFieldsPresent_success() {
+        Index targetIndex = INDEX_FIRST_PERSON;
+        String userInput = targetIndex.getOneBased() + VALID_ORDER_STRING;
+
+        assertParseSuccess(parser, userInput, new AddOrderCommand(INDEX_FIRST_PERSON, ATLAS));
+    }
+
+    @Test
+    public void parse_missingParts_failure() {
+        // no index specified
+        assertParseFailure(parser, VALID_ORDER_STRING, MESSAGE_INVALID_FORMAT);
+
+        // no field specified
+        assertParseFailure(parser, "2", MESSAGE_INVALID_FORMAT);
+
+        // no index and no fieldspecified
+        assertParseFailure(parser, "", MESSAGE_INVALID_FORMAT);
+    }
+
+    @Test
+    public void parse_someFieldsPresent_failure() {
+        // missing item prefix
+        assertParseFailure(parser, "1 " + VALID_ITEM_ATLAS + DATE_DESC_ATLAS + COUNT_DESC_ATLAS,
+                MESSAGE_INVALID_FORMAT);
+
+        // missing date prefix
+        assertParseFailure(parser, "1" + ITEM_DESC_ATLAS + VALID_DATE_ATLAS + COUNT_DESC_ATLAS,
+                MESSAGE_INVALID_FORMAT);
+
+        // missing count prefix
+        assertParseFailure(parser, "1" + ITEM_DESC_ATLAS + DATE_DESC_ATLAS + VALID_COUNT_ATLAS,
+                MESSAGE_INVALID_FORMAT);
+
+        // all prefixes missing
+        assertParseFailure(parser, "1 " + VALID_ITEM_ATLAS + VALID_DATE_ATLAS + VALID_COUNT_ATLAS,
+                MESSAGE_INVALID_FORMAT);
+    }
+
+    @Test
+    public void parse_invalidPreamble_failure() {
+        // negative index
+        assertParseFailure(parser, "-2" + VALID_ORDER_STRING, MESSAGE_INVALID_FORMAT);
+
+        // zero index
+        assertParseFailure(parser, "0" + VALID_ORDER_STRING, MESSAGE_INVALID_FORMAT);
+
+        // invalid arguments being parsed as preamble
+        assertParseFailure(parser, "1 some random string" + VALID_ORDER_STRING, MESSAGE_INVALID_FORMAT);
+
+        // invalid prefix being parsed as preamble
+        assertParseFailure(parser, "1 n/ string" + VALID_ORDER_STRING, MESSAGE_INVALID_FORMAT);
+    }
+
+    @Test
+    public void parse_invalidValue_failure() {
+        // invalid name
+        assertParseFailure(parser, "1" + INVALID_ITEM_DESC + DATE_DESC_ATLAS + COUNT_DESC_ATLAS,
+                Item.MESSAGE_CONSTRAINTS);
+
+        // invalid date
+        assertParseFailure(parser, "1" + ITEM_DESC_ATLAS + INVALID_DATE_DESC + COUNT_DESC_ATLAS,
+                Date.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, "1" + ITEM_DESC_ATLAS + INVALID_DATE_DIGIT + COUNT_DESC_ATLAS,
+                Date.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, "1" + ITEM_DESC_ATLAS + INVALID_DATE_NO_HYPHEN + COUNT_DESC_ATLAS,
+                Date.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, "1" + ITEM_DESC_ATLAS + INVALID_DATE_VALUE + COUNT_DESC_ATLAS,
+                Date.MESSAGE_CONSTRAINTS);
+
+        // invalid count
+        assertParseFailure(parser, "1" + ITEM_DESC_ATLAS + DATE_DESC_ATLAS + INVALID_COUNT_ZERO,
+                Count.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, "1" + ITEM_DESC_ATLAS + DATE_DESC_ATLAS + INVALID_COUNT_STRING,
+                Count.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, "1" + ITEM_DESC_ATLAS + DATE_DESC_ATLAS + INVALID_COUNT_NEGATIVE,
+                Count.MESSAGE_CONSTRAINTS);
+    }
+
+    @Test
+    public void parse_multipleRepeatedFields_failure() {
+        Index targetIndex = INDEX_FIRST_PERSON;
+        String validUserInput = targetIndex.getOneBased() + VALID_ORDER_STRING;
+
+        // multiple item names
+        assertParseFailure(parser, targetIndex.getOneBased() + VALID_ORDER_STRING + ITEM_DESC_ATLAS,
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_ITEM));
+
+        // multiple dates
+        assertParseFailure(parser, targetIndex.getOneBased() + VALID_ORDER_STRING + DATE_DESC_ATLAS,
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_DATE));
+
+        // multiple counts
+        assertParseFailure(parser, targetIndex.getOneBased() + VALID_ORDER_STRING + COUNT_DESC_ATLAS,
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_COUNT));
+
+        // multiple fields repeated
+        assertParseFailure(parser, targetIndex.getOneBased() + VALID_ORDER_STRING
+                        + ITEM_DESC_BOTTLE + DATE_DESC_BOTTLE + COUNT_DESC_BOTTLE,
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_ITEM, PREFIX_DATE, PREFIX_COUNT));
+
+        // invalid value followed by valid value
+
+        // invalid item name
+        assertParseFailure(parser, targetIndex.getOneBased() + INVALID_ITEM_DESC + VALID_ORDER_STRING,
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_ITEM));
+
+        // invalid dates
+        assertParseFailure(parser, targetIndex.getOneBased() + INVALID_DATE_DESC + VALID_ORDER_STRING,
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_DATE));
+
+        assertParseFailure(parser, targetIndex.getOneBased() + INVALID_DATE_DIGIT + VALID_ORDER_STRING,
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_DATE));
+
+        assertParseFailure(parser, targetIndex.getOneBased() + INVALID_DATE_VALUE + VALID_ORDER_STRING,
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_DATE));
+
+        assertParseFailure(parser, targetIndex.getOneBased() + INVALID_DATE_NO_HYPHEN + VALID_ORDER_STRING,
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_DATE));
+
+        // invalid counts
+        assertParseFailure(parser, targetIndex.getOneBased() + INVALID_COUNT_NEGATIVE + VALID_ORDER_STRING,
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_COUNT));
+
+        assertParseFailure(parser, targetIndex.getOneBased() + INVALID_COUNT_ZERO + VALID_ORDER_STRING,
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_COUNT));
+
+        assertParseFailure(parser, targetIndex.getOneBased() + INVALID_COUNT_STRING + VALID_ORDER_STRING,
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_COUNT));
+
+        // valid value followed by invalid value
+
+        // invalid item name
+        assertParseFailure(parser, targetIndex.getOneBased() + VALID_ORDER_STRING + INVALID_ITEM_DESC,
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_ITEM));
+
+        // invalid dates
+        assertParseFailure(parser, targetIndex.getOneBased() + VALID_ORDER_STRING + INVALID_DATE_DESC,
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_DATE));
+
+        assertParseFailure(parser, targetIndex.getOneBased() + VALID_ORDER_STRING + INVALID_DATE_DIGIT,
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_DATE));
+
+        assertParseFailure(parser, targetIndex.getOneBased() + VALID_ORDER_STRING + INVALID_DATE_VALUE,
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_DATE));
+
+        assertParseFailure(parser, targetIndex.getOneBased() + VALID_ORDER_STRING + INVALID_DATE_NO_HYPHEN,
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_DATE));
+
+        // invalid counts
+        assertParseFailure(parser, targetIndex.getOneBased() + VALID_ORDER_STRING + INVALID_COUNT_NEGATIVE,
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_COUNT));
+
+        assertParseFailure(parser, targetIndex.getOneBased() + VALID_ORDER_STRING + INVALID_COUNT_ZERO,
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_COUNT));
+
+        assertParseFailure(parser, targetIndex.getOneBased() + VALID_ORDER_STRING + INVALID_COUNT_STRING,
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_COUNT));
     }
 }

--- a/src/test/java/seedu/sellsavvy/logic/parser/EditPersonCommandParserTest.java
+++ b/src/test/java/seedu/sellsavvy/logic/parser/EditPersonCommandParserTest.java
@@ -179,7 +179,7 @@ public class EditPersonCommandParserTest {
 
         assertParseFailure(parser, userInput, Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE));
 
-        // mulltiple valid fields repeated
+        // multiple valid fields repeated
         userInput = targetIndex.getOneBased() + PHONE_DESC_AMY + ADDRESS_DESC_AMY + EMAIL_DESC_AMY
                 + TAG_DESC_FRIEND + PHONE_DESC_AMY + ADDRESS_DESC_AMY + EMAIL_DESC_AMY + TAG_DESC_FRIEND
                 + PHONE_DESC_BOB + ADDRESS_DESC_BOB + EMAIL_DESC_BOB + TAG_DESC_HUSBAND;

--- a/src/test/java/seedu/sellsavvy/testutil/PersonBuilder.java
+++ b/src/test/java/seedu/sellsavvy/testutil/PersonBuilder.java
@@ -3,6 +3,7 @@ package seedu.sellsavvy.testutil;
 import java.util.HashSet;
 import java.util.Set;
 
+import seedu.sellsavvy.model.order.Order;
 import seedu.sellsavvy.model.order.OrderList;
 import seedu.sellsavvy.model.person.Address;
 import seedu.sellsavvy.model.person.Email;
@@ -27,7 +28,7 @@ public class PersonBuilder {
     private Email email;
     private Address address;
     private Set<Tag> tags;
-    private OrderList orders; //TODO: withOrders() method for creating orders on Person creation
+    private OrderList orders;
 
     /**
      * Creates a {@code PersonBuilder} with the default details.
@@ -90,6 +91,18 @@ public class PersonBuilder {
      */
     public PersonBuilder withEmail(String email) {
         this.email = new Email(email);
+        return this;
+    }
+
+    /**
+     * Sets the {@code OrderList} of the {@code Person} that we are building.
+     */
+    public PersonBuilder withOrders(Order... orders) {
+        OrderList orderList = new OrderList();
+        for (Order order: orders) {
+            orderList.add(order);
+        }
+        this.orders = orderList;
         return this;
     }
 

--- a/src/test/java/seedu/sellsavvy/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/sellsavvy/testutil/TypicalPersons.java
@@ -10,6 +10,7 @@ import static seedu.sellsavvy.logic.commands.personcommands.PersonCommandTestUti
 import static seedu.sellsavvy.logic.commands.personcommands.PersonCommandTestUtil.VALID_PHONE_BOB;
 import static seedu.sellsavvy.logic.commands.personcommands.PersonCommandTestUtil.VALID_TAG_FRIEND;
 import static seedu.sellsavvy.logic.commands.personcommands.PersonCommandTestUtil.VALID_TAG_HUSBAND;
+import static seedu.sellsavvy.testutil.TypicalOrders.ABACUS;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -30,7 +31,7 @@ public class TypicalPersons {
     public static final Person BENSON = new PersonBuilder().withName("Benson Meier")
             .withAddress("311, Clementi Ave 2, #02-25")
             .withEmail("johnd@example.com").withPhone("98765432")
-            .withTags("owesMoney", "friends").build();
+            .withTags("owesMoney", "friends").withOrders(ABACUS).build();
     public static final Person CARL = new PersonBuilder().withName("Carl Kurz").withPhone("95352563")
             .withEmail("heinz@example.com").withAddress("wall street").build();
     public static final Person DANIEL = new PersonBuilder().withName("Daniel Meier").withPhone("87652533")

--- a/src/test/java/seedu/sellsavvy/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/sellsavvy/testutil/TypicalPersons.java
@@ -10,7 +10,6 @@ import static seedu.sellsavvy.logic.commands.personcommands.PersonCommandTestUti
 import static seedu.sellsavvy.logic.commands.personcommands.PersonCommandTestUtil.VALID_PHONE_BOB;
 import static seedu.sellsavvy.logic.commands.personcommands.PersonCommandTestUtil.VALID_TAG_FRIEND;
 import static seedu.sellsavvy.logic.commands.personcommands.PersonCommandTestUtil.VALID_TAG_HUSBAND;
-import static seedu.sellsavvy.testutil.TypicalOrders.ABACUS;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -31,7 +30,7 @@ public class TypicalPersons {
     public static final Person BENSON = new PersonBuilder().withName("Benson Meier")
             .withAddress("311, Clementi Ave 2, #02-25")
             .withEmail("johnd@example.com").withPhone("98765432")
-            .withTags("owesMoney", "friends").withOrders(ABACUS).build();
+            .withTags("owesMoney", "friends").build();
     public static final Person CARL = new PersonBuilder().withName("Carl Kurz").withPhone("95352563")
             .withEmail("heinz@example.com").withAddress("wall street").build();
     public static final Person DANIEL = new PersonBuilder().withName("Daniel Meier").withPhone("87652533")


### PR DESCRIPTION
Implement `addOrder` command
* Command format: `addOrder INDEX i/ITEM_NAME d/DELIVERY_BY c/ITEM_COUNT`
* NAME has been changed to INDEX
* ITEM_COUNT is currently compulsory
* Add a way to format `Orders` in `seedu.sellsavvy.logic.Messages` class

Close #54 