### PR TITLE
Change GUI message displayed when there are no orders or customers

### DIFF
--- a/src/main/java/seedu/sellsavvy/model/Model.java
+++ b/src/main/java/seedu/sellsavvy/model/Model.java
@@ -16,7 +16,7 @@ import seedu.sellsavvy.model.person.Person;
  */
 public interface Model {
     /** {@code Predicate} that always evaluate to true */
-    Predicate<Person> PREDICATE_SHOW_ALL_PERSONS = unused -> true;
+    static Predicate<Person> PREDICATE_SHOW_ALL_PERSONS = unused -> true;
 
     /**
      * Replaces user prefs data with the data in {@code userPrefs}.

--- a/src/main/java/seedu/sellsavvy/model/person/Person.java
+++ b/src/main/java/seedu/sellsavvy/model/person/Person.java
@@ -99,7 +99,7 @@ public class Person {
     }
 
     /**
-     * Returns the predicate applied to get {@code filteredOrders}.
+     * Returns true if the filtered order list is filtered under certain conditions.
      */
     public boolean areOrdersFiltered() {
         return filteredOrders.getPredicate() != PREDICATE_SHOW_ALL_ORDERS;

--- a/src/main/java/seedu/sellsavvy/model/person/Person.java
+++ b/src/main/java/seedu/sellsavvy/model/person/Person.java
@@ -99,6 +99,13 @@ public class Person {
     }
 
     /**
+     * Returns the predicate applied to get {@code filteredOrders}.
+     */
+    public boolean areOrdersFiltered() {
+        return filteredOrders.getPredicate() != PREDICATE_SHOW_ALL_ORDERS;
+    }
+
+    /**
      * Updates the filter of the order list to filter by the given {@code predicate}.
      * @throws NullPointerException if {@code predicate} is null.
      */

--- a/src/main/java/seedu/sellsavvy/model/person/Person.java
+++ b/src/main/java/seedu/sellsavvy/model/person/Person.java
@@ -102,7 +102,8 @@ public class Person {
      * Returns true if the filtered order list is filtered under certain conditions.
      */
     public boolean areOrdersFiltered() {
-        return filteredOrders.getPredicate() != PREDICATE_SHOW_ALL_ORDERS;
+        return filteredOrders.getPredicate() != PREDICATE_SHOW_ALL_ORDERS
+                && filteredOrders.getPredicate() != null;
     }
 
     /**

--- a/src/main/java/seedu/sellsavvy/ui/OrderListPanel.java
+++ b/src/main/java/seedu/sellsavvy/ui/OrderListPanel.java
@@ -14,7 +14,6 @@ import javafx.scene.layout.Region;
 import seedu.sellsavvy.commons.core.LogsCenter;
 import seedu.sellsavvy.logic.commands.ordercommands.ListOrderCommand;
 import seedu.sellsavvy.model.order.Order;
-import seedu.sellsavvy.model.order.OrderList;
 import seedu.sellsavvy.model.person.Person;
 
 /**

--- a/src/main/java/seedu/sellsavvy/ui/OrderListPanel.java
+++ b/src/main/java/seedu/sellsavvy/ui/OrderListPanel.java
@@ -24,6 +24,7 @@ public class OrderListPanel extends UiPart<Region> {
     private static final String DEFAULT_TITLE = "Order";
     private static final String TITLE_WITH_SELECTED_PERSON = "Order (%1$s)";
     private static final String EMPTY_ORDER_LIST_MESSAGE = "This customer does not have any orders currently.";
+    private static final String NO_RELATED_ORDERS_FOUND = "No related orders found.";
 
     private final Logger logger = LogsCenter.getLogger(OrderListPanel.class);
     private final ListChangeListener<Order> orderChangeListener = change -> handleChangeInOrders();
@@ -71,7 +72,7 @@ public class OrderListPanel extends UiPart<Region> {
         orderListView.setCellFactory(listView -> new OrderListViewCell());
 
         if (orderList.isEmpty()) {
-            showEmptyOrderLabel();
+            showNoOrdersLabel();
             return;
         }
 
@@ -102,8 +103,8 @@ public class OrderListPanel extends UiPart<Region> {
      * Handles events whether a customer's orders changes.
      */
     private void handleChangeInOrders() {
-        if (orderListView.getItems().isEmpty() && !selectedPerson.areOrdersFiltered()) {
-            showEmptyOrderLabel();
+        if (orderListView.getItems().isEmpty()) {
+            showNoOrdersLabel();
         } else {
             showOrderList();
         }
@@ -121,9 +122,14 @@ public class OrderListPanel extends UiPart<Region> {
     /**
      * Displays the label to show that the order list is empty.
      */
-    private void showEmptyOrderLabel() {
-
+    private void showNoOrdersLabel() {
         clearComponentVisibility();
+        if (selectedPerson.areOrdersFiltered()) {
+            orderListEmpty.setText(NO_RELATED_ORDERS_FOUND);
+        } else {
+            orderListEmpty.setText(EMPTY_ORDER_LIST_MESSAGE);
+        }
+
         orderListEmpty.setManaged(true);
         orderListEmpty.setVisible(true);
     }

--- a/src/main/java/seedu/sellsavvy/ui/PersonListPanel.java
+++ b/src/main/java/seedu/sellsavvy/ui/PersonListPanel.java
@@ -1,9 +1,14 @@
 package seedu.sellsavvy.ui;
 
+import static seedu.sellsavvy.model.Model.PREDICATE_SHOW_ALL_PERSONS;
+
 import java.util.logging.Logger;
 
+import javafx.collections.ListChangeListener;
 import javafx.collections.ObservableList;
+import javafx.collections.transformation.FilteredList;
 import javafx.fxml.FXML;
+import javafx.scene.control.Label;
 import javafx.scene.control.ListCell;
 import javafx.scene.control.ListView;
 import javafx.scene.layout.Region;
@@ -15,18 +20,57 @@ import seedu.sellsavvy.model.person.Person;
  */
 public class PersonListPanel extends UiPart<Region> {
     private static final String FXML = "PersonListPanel.fxml";
+    private static final String EMPTY_PERSON_LIST_MESSAGE = "You do not have any recorded customers currently.";
+    private static final String NO_RELATED_PERSONS_FOUND = "No related customers found.";
     private final Logger logger = LogsCenter.getLogger(PersonListPanel.class);
+    private final ListChangeListener<Person> orderChangeListener = change -> handleChangeInPersons();
+    private ObservableList<Person> personList;
 
     @FXML
     private ListView<Person> personListView;
+    @FXML
+    private Label personListEmpty;
 
     /**
      * Creates a {@code PersonListPanel} with the given {@code ObservableList}.
      */
     public PersonListPanel(ObservableList<Person> personList) {
         super(FXML);
+        this.personList = personList;
+        personList.addListener(orderChangeListener);;
         personListView.setItems(personList);
         personListView.setCellFactory(listView -> new PersonListViewCell());
+    }
+
+    /**
+     * Handles events whether a displayed person list changes.
+     */
+    private void handleChangeInPersons() {
+        toggleNoPersonsLabel(personListView.getItems().isEmpty());
+    }
+
+    /**
+     * Toggles whether the {@code personListEmpty} is displayed and determines the
+     * message displayed.
+     */
+    private void toggleNoPersonsLabel(boolean personListIsEmpty) {
+        setPersonListEmptyText();
+        personListEmpty.setManaged(personListIsEmpty);
+        personListEmpty.setVisible(personListIsEmpty);
+        personListView.setManaged(!personListIsEmpty);
+        personListView.setVisible(!personListIsEmpty);
+    }
+
+    /**
+     * Sets the text displayed in {@code personListEmpty}.
+     */
+    private void setPersonListEmptyText() {
+        FilteredList<Person> filteredList = (FilteredList<Person>) personList;
+        if (filteredList.getPredicate() == PREDICATE_SHOW_ALL_PERSONS) {
+            personListEmpty.setText(EMPTY_PERSON_LIST_MESSAGE);
+        } else {
+            personListEmpty.setText(NO_RELATED_PERSONS_FOUND);
+        }
     }
 
     /**

--- a/src/main/resources/view/OrderListPanel.fxml
+++ b/src/main/resources/view/OrderListPanel.fxml
@@ -7,5 +7,6 @@
 <VBox xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1">
     <Label fx:id="orderListTitle" text="Order List" styleClass="label-title" VBox.vgrow="NEVER" maxWidth="Infinity" />
     <ListView fx:id="orderListView" VBox.vgrow="ALWAYS" />
+    <Label fx:id="orderListEmpty" styleClass="label-instruction" VBox.vgrow="ALWAYS" maxWidth="Infinity" wrapText="true" />
     <Label fx:id="orderGuide" styleClass="label-instruction" VBox.vgrow="ALWAYS" maxWidth="Infinity" wrapText="true" />
 </VBox>

--- a/src/main/resources/view/PersonListPanel.fxml
+++ b/src/main/resources/view/PersonListPanel.fxml
@@ -7,4 +7,5 @@
 <VBox xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1">
   <Label text="Customer List" styleClass="label-title" VBox.vgrow="NEVER" maxWidth="Infinity" />
   <ListView fx:id="personListView" VBox.vgrow="ALWAYS" />
+  <Label fx:id="personListEmpty" styleClass="label-instruction" VBox.vgrow="ALWAYS" maxWidth="Infinity" wrapText="true" />
 </VBox>

--- a/src/test/java/seedu/sellsavvy/model/person/PersonTest.java
+++ b/src/test/java/seedu/sellsavvy/model/person/PersonTest.java
@@ -103,4 +103,20 @@ public class PersonTest {
         assertThrows(UnsupportedOperationException.class, ()
                 -> ALICE.getFilteredOrderList().remove(0));
     }
+
+    @Test
+    public void areOrdersFiltered() {
+        Person aliceCopy = new PersonBuilder(ALICE).build();
+
+        // order list not filtered -> returns false
+        assertFalse(aliceCopy.areOrdersFiltered());
+
+        // order list filtered -> returns true
+        aliceCopy.updateFilteredOrderList(order -> false);
+        assertTrue(aliceCopy.areOrdersFiltered());
+
+        // order list reset -> returns false
+        aliceCopy.resetFilteredOrderList();
+        assertFalse(aliceCopy.areOrdersFiltered());
+    }
 }


### PR DESCRIPTION
Close #74 

Only displays a message that the customer does not have any orders if the customer has no orders and the orders are not filtered.
When no orders are found upon filtering, the OrderListPanel does not display anything. Reason behind this is the CLI response already indicates "0 xxx orders listed!", similar to how filtering from a list containing nothing still displays the list, but the list is just empty.

After using `listOrder` on a customer with no orders:
![image](https://github.com/user-attachments/assets/8bdbb5e0-c86d-46ec-bbe0-8b1ba87dfd1b)

Filtered order but no orders listed:
![image](https://github.com/user-attachments/assets/fbecf3f4-74fb-45fe-b618-c79ec991afc6)

After deleting the last order a customer has:
![image](https://github.com/user-attachments/assets/811eb476-48a3-4862-8d07-2631b132daa3)
