### PR TITLE
Fix Customer Name handling bug and constraints message error

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -102,7 +102,7 @@ Examples:
 ##### Constraints
 
 * `NAME` can only contain alphanumeric characters, spaces, and one of the following symbols: hyphen, comma, and apostrophe, where commas should be followed with a space.
-* `NAME` should have alphanumeric characters before and after the symbol, and it should not be blank. Relationship indicator using "S/O" or "D/O" can be included but should be wrapped with spaces, and followed with the name of customer with stated relationship.
+* `NAME` should have alphanumeric characters before and after the symbol, and it should not be blank. Relationship indicator using "S/O" or "D/O" can be included but should be wrapped with a single space, and followed with the name of customer with stated relationship.
 * Duplicated `NAME` is not allowed.
 * If there is already a customer with similar `NAME` (same name excluding space and casing), a warning will be given.
 * `PHONE_NUMBER` should only contains numbers, and it should at least be 3 digits long.

--- a/src/main/java/seedu/sellsavvy/model/customer/Name.java
+++ b/src/main/java/seedu/sellsavvy/model/customer/Name.java
@@ -17,13 +17,13 @@ public class Name {
                     + "Names should have alphanumeric characters before and after the symbol, "
                     + "and it should not be blank.\n"
                     + "Relationship indicator using \"S/O\" or \"D/O\" can be included but should be wrapped "
-                    + "with spaces, and followed with the name of the customer with stated relationship.";
+                    + "with a single space, and followed with the name of the customer with stated relationship.";
 
     /*
      * The first character of a name must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.
      */
-    public static final String ALPHANUMERIC_WITH_SPACE = "[\\p{Alnum}][\\p{Alnum} ]*";
+    public static final String ALPHANUMERIC_WITH_SPACE = "[\\p{Alnum}]([\\p{Alnum} ]*[\\p{Alnum}])?";
     public static final String NAME_REGEX = ALPHANUMERIC_WITH_SPACE + "((,\\s|'|-)" + ALPHANUMERIC_WITH_SPACE + ")?";
     public static final String RELATIONSHIP_REGEX = "\\s(S/O|D/O)\\s" + NAME_REGEX;
     public static final String VALIDATION_REGEX = "^" + NAME_REGEX + "(" + RELATIONSHIP_REGEX + ")?$";

--- a/src/main/java/seedu/sellsavvy/model/customer/Name.java
+++ b/src/main/java/seedu/sellsavvy/model/customer/Name.java
@@ -26,7 +26,7 @@ public class Name {
     public static final String ALPHANUMERIC_WITH_SPACE = "[\\p{Alnum}]([\\p{Alnum} ]*[\\p{Alnum}])?";
     public static final String NAME_REGEX = ALPHANUMERIC_WITH_SPACE + "((,\\s|'|-)" + ALPHANUMERIC_WITH_SPACE + ")?";
     public static final String RELATIONSHIP_REGEX = "\\s(S/O|D/O)\\s" + NAME_REGEX;
-    public static final String VALIDATION_REGEX = "^" + NAME_REGEX + "(" + RELATIONSHIP_REGEX + ")?$";
+    public static final String VALIDATION_REGEX = "^" + NAME_REGEX + "(" + RELATIONSHIP_REGEX + ")?[ ]*$";
 
     public final String fullName;
 


### PR DESCRIPTION
Fix an incorrect handling of allowed Name formats and subsequent insufficient message of format constraints

Name allows for Name inputs such as `John -Doe` and `Adam  S/O Tim`, which are not necessarily accepted naming conventions in real-world contexts. This is affected and completed in PR #136. Given the stated constraints in the User Guide, indicates that such name inputs should not be accepted, thus buggy behaviour of the Name validity check.

Modifying the regular expression for Name parameter would ensure that the checker adheres to the more stringent accepted naming format. Further, updating the constraints message provided is necessary to reflect the change made to the regex for Name validity checks. 

Updating the Name constraints message would ensure that users are informed of the accepted naming convention, thereby resolving the bug identified in issue #262.
Resolving the buggy naming format handled by the Name regex would ensure that the inclusion of accepted special symbols like `-` is adhered to and checked for validity, thereby addressing issue #292.

Close #262
Close #292