### PR TITLE
Fix bug where clear command does not clear order list

### DIFF
--- a/src/main/java/seedu/sellsavvy/logic/commands/generalcommands/ClearCommand.java
+++ b/src/main/java/seedu/sellsavvy/logic/commands/generalcommands/ClearCommand.java
@@ -20,6 +20,7 @@ public class ClearCommand extends Command {
     public CommandResult execute(Model model) {
         requireNonNull(model);
         model.setAddressBook(new AddressBook());
+        model.updateSelectedCustomer(null);
         return new CommandResult(MESSAGE_SUCCESS);
     }
 }


### PR DESCRIPTION
close #320 

In ISSUE #64 , we found a bug where deleting a customer whose order is deleted does not clear the displayed order list when the particular customer's `Orderlist` is displayed.
In PR #98 , we fixed the bug by editing the `deletecustomer` command to clear the order list if the selected customer's orders is displayed.
However, we forgot that `clear` command can also potentially delete the customer whose order is displayed similar to delete customer command, hence didn't fixed it by then.
In the current implementation using `clear` to delete all customers does not clear the displayed order list which we did fix for `deletecustomer` command.

![image](https://github.com/user-attachments/assets/d47a9c80-86c4-4586-853c-248a1240c04b)


Since this is a behaviour added for other similar command and is strictly wrong behaviour (customer should not be able to edit a deleted order list), which we overlooked in previous commit, it is justifiable for us to edit it as a functionality bug in v1.6.
![image](https://github.com/user-attachments/assets/5a2fbf02-0713-45cd-a2b3-520cc00aac46)
